### PR TITLE
SEO: update meta descriptions to remove duplicates (archive)

### DIFF
--- a/programming/android/auxiliary-api/capabilities.md
+++ b/programming/android/auxiliary-api/capabilities.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Capabilities - DynamsoftCameraEnhancer Android Edition API Reference
-description: The class Capabilities of DynamsoftCameraEnhancer represents the capability properties of the hardware, including the maximum zoom factor, focal length, exposure time, and ISO.
+description: "Learn what Capabilities does in Dynamsoft Camera Enhancer Android API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: capabilities, hardware, Java, Kotlin
 needGenerateH3Content: true
 needAutoGenerateSidebar: true

--- a/programming/android/auxiliary-api/dcecameraview.md
+++ b/programming/android/auxiliary-api/dcecameraview.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: CameraView - Dynamsoft Camera SDK API Reference
-description: The class CameraView of Dynamsoft Camera SDK represents a camera view that displays the camera preview and provides UI controlling APIs.
+description: "Learn what CameraView does in Dynamsoft Camera Enhancer Android API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: camera view, Java, Kotlin
 needGenerateH3Content: true
 needAutoGenerateSidebar: true

--- a/programming/android/auxiliary-api/drawingitem.md
+++ b/programming/android/auxiliary-api/drawingitem.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: DrawingItem - DynamsoftCameraEnhancer Android Edition API Reference
-description: The class DrawingItem of DynamsoftCameraEnhancer represents a base class for drawing items, which can be added to drawing layers to draw basic graphics on the view.
+description: "Learn what DrawingItem does in Dynamsoft Camera Enhancer Android API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: drawing item, Java, Kotlin
 needGenerateH3Content: true
 needAutoGenerateSidebar: true

--- a/programming/android/guide/scan-region.md
+++ b/programming/android/guide/scan-region.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Set a Scan Region - Exploring Features of Dynamsoft Camera Enhancer Android Edition.
-description: This page introduce how to set a scan region with Dynamsoft Camera Enhancer Android Edition.
+description: "Learn how to use Dynamsoft Camera Enhancer Android features with practical setup guidance, workflow tips, and examples for building reliable capture apps."
 keywords:  Camera Enhancer, Customize Camera Settings
 needAutoGenerateSidebar: true
 noTitleIndex: true

--- a/programming/ios/auxiliary-api/capabilities.md
+++ b/programming/ios/auxiliary-api/capabilities.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: DSCapabilities - DynamsoftCameraEnhancer iOS Edition API Reference
-description: The class DSCapabilities of DynamsoftCameraEnhancer represents the capability properties of the hardware, including the maximum zoom factor, focal length, exposure time, and ISO.
+description: "Learn what DSCapabilities does in Dynamsoft Camera Enhancer iOS API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: capabilities, hardware, objective-c, swift
 needGenerateH3Content: true
 needAutoGenerateSidebar: true

--- a/programming/ios/auxiliary-api/dcecameraview.md
+++ b/programming/ios/auxiliary-api/dcecameraview.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: DSCameraView - Dynamsoft Camera SDK API Reference
-description: The class DSCameraView of Dynamsoft Camera SDK represents a camera view that displays the camera preview and provides UI controlling APIs.
+description: "Learn what DSCameraView does in Dynamsoft Camera Enhancer iOS API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: camera view, objective-c, swift
 needGenerateH3Content: true
 needAutoGenerateSidebar: true

--- a/programming/ios/auxiliary-api/protocol-dceframelistener.md
+++ b/programming/ios/auxiliary-api/protocol-dceframelistener.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: DSVideoFrameListener - Dynamsoft Camera Enhancer Module iOS Edition API Reference
-description: The protocol that defines methos for monitoring the video frame output.
+description: "Learn what the Dceframelistener protocol does in Dynamsoft Camera Enhancer iOS SDK and how it helps monitor camera, frame, or click events for modern web."
 keywords: Video frame listener, objective-c, swift
 needGenerateH3Content: true
 needAutoGenerateSidebar: true

--- a/programming/ios/guide/scan-region.md
+++ b/programming/ios/guide/scan-region.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Set a Scan Region - Exploring Features of Dynamsoft Camera Enhancer iOS Edition.
-description: This page introduce how to set a scan region with Dynamsoft Camera Enhancer iOS Edition.
+description: "Learn how to use Dynamsoft Camera Enhancer iOS features with practical setup guidance, workflow tips, and examples for building reliable capture apps."
 keywords:  Camera Enhancer, scan region
 needAutoGenerateSidebar: true
 noTitleIndex: true


### PR DESCRIPTION
Update 8 meta descriptions in archived Android and iOS pages to remove duplicates.